### PR TITLE
Updated logic to check if req.query exists when visiting / route.

### DIFF
--- a/routes/shops.js
+++ b/routes/shops.js
@@ -10,7 +10,7 @@ router.get('/', async (req, res) => {
   let result;
   let resultStatus;
 
-  if (!req.query) {
+  if (Object.keys(req.query).length === 0) {
     result = await shopData.getAllShops();
   } else {
     let state = req.query.state.toUpperCase();


### PR DESCRIPTION
If there are no query string parameters, `req.query` still exists as an empty object. As such, we can't check it with !req.query. Rather, we need to convert it to an array and then check if the array length === 0.